### PR TITLE
[INTERNAL] Allow intra-broker goals to be used as default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,31 +33,11 @@ jobs:
           path: ~/test-results
       - store_artifacts:
           path: build/libs
-
-  publish:
-    working_directory: ~/workspace
-    docker:
-      - image: circleci/openjdk:11-jdk
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "build.gradle" }}
-      - run:
-          command: ./gradlew :artifactoryPublish :cruise-control:artifactoryPublish :cruise-control-core:artifactoryPublish :cruise-control-metrics-reporter:artifactoryPublish
-
 workflows:
   version: 2
-  build-and-publish:
+  build:
     jobs:
       - build:
           filters:
             tags:
               only: /.*/
-      - publish:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,0 +1,22 @@
+name: build-publish-docker-image
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # https://github.com/docker/build-push-action
+      - uses: docker/build-push-action@v1
+        with:
+          dockerfile: docker/Dockerfile
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: adobe/cruise-control
+          tag_with_ref: true
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          add_git_labels: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Cruise Control for Apache Kafka
 ===================
 
-[![CircleCI](https://circleci.com/gh/linkedin/cruise-control.svg?style=svg)](https://circleci.com/gh/linkedin/cruise-control)
+[![CircleCI](https://circleci.com/gh/adobe/cruise-control.svg?style=svg)](https://circleci.com/gh/adobe/cruise-control)  
+[![Github Actions](https://github.com/adobe/cruise-control/workflows/build-publish-docker-image/badge.svg)](https://github.com/adobe/cruise-control/workflows/build-publish-docker-image/badge.svg)  
+[![Docker Hub](https://img.shields.io/docker/v/adobe/cruise-control?sort=date&style=plastic)](https://hub.docker.com/r/adobe/cruise-control/tags)
 
 ### Introduction ###
   Cruise Control is a product that helps run Apache Kafka clusters at large scale. Due to the popularity of 

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/CruiseControlMetricsReporter.java
@@ -384,7 +384,7 @@ public class CruiseControlMetricsReporter implements MetricsReporter, Runnable {
       @Override
       public void onCompletion(RecordMetadata recordMetadata, Exception e) {
         if (e != null) {
-          LOG.warn("Failed to send Cruise Control metric {}", ccm);
+          LOG.warn("Failed to send Cruise Control metric {}", ccm, e);
           _numMetricSendFailure++;
         }
       }

--- a/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/MetricsUtils.java
+++ b/cruise-control-metrics-reporter/src/main/java/com/linkedin/kafka/cruisecontrol/metricsreporter/metric/MetricsUtils.java
@@ -166,10 +166,16 @@ public class MetricsUtils {
    * @return the "recent CPU usage" for the JVM process as a double in [0.0,1.0].
    */
   public static BrokerMetric getCpuMetric(long now, int brokerId, boolean kubernetesMode) throws IOException {
-    double cpuUtil = ((com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getProcessCpuLoad();
 
+    double cpuUtil;
     if (kubernetesMode) {
-      cpuUtil = ContainerMetricUtils.getContainerProcessCpuLoad(cpuUtil);
+      // we are using openjdk>=14 runtime in k8s environments so
+      // the process cpu utilization is computed as: system_load/no_of_processors
+      com.sun.management.OperatingSystemMXBean systemMXBean =
+              (com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+      cpuUtil = systemMXBean.getSystemCpuLoad() / systemMXBean.getAvailableProcessors();
+    } else {
+      cpuUtil = ((com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getProcessCpuLoad();
     }
 
     if (cpuUtil < 0) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/KafkaCruiseControlConfig.java
@@ -153,11 +153,12 @@ public class KafkaCruiseControlConfig extends AbstractConfig {
       throw new ConfigException("Attempt to configure default goals configuration with an empty list of goals.");
     }
 
-    // Ensure that default goals are supported inter-broker goals.
-    if (defaultGoalNames.stream().anyMatch(g -> !interBrokerGoalNames.contains(g))) {
-      throw new ConfigException(String.format("Attempt to configure default goals with unsupported goals (%s:%s and %s:%s).",
-                                              AnalyzerConfig.DEFAULT_GOALS_CONFIG, defaultGoalNames,
-                                              AnalyzerConfig.GOALS_CONFIG, interBrokerGoalNames));
+    // Ensure that default goals are supported inter-broker or intra-brokers goals.
+    if (defaultGoalNames.stream().anyMatch(g -> !(interBrokerGoalNames.contains(g) || intraBrokerGoalNames.contains(g)))) {
+      throw new ConfigException(String.format("Attempt to configure default goals with unsupported goals (%s:%s, %s:%s and %s:%s).",
+          AnalyzerConfig.DEFAULT_GOALS_CONFIG, defaultGoalNames,
+          AnalyzerConfig.GOALS_CONFIG, interBrokerGoalNames,
+          AnalyzerConfig.INTRA_BROKER_GOALS_CONFIG, intraBrokerGoalNames));
     }
 
     // Ensure that hard goals are contained in default goals.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-debian-slim
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates
+RUN mkdir /cruise-control
+COPY . /cruise-control
+RUN cd cruise-control && echo && ./gradlew jar copyDependantLibs
+
+RUN mv -v /cruise-control/cruise-control/build/libs/cruise-control-*.jar \
+  /cruise-control/cruise-control/build/libs/cruise-control.jar
+RUN mv -v /cruise-control/cruise-control/build/dependant-libs/cruise-control-metrics-reporter-*.jar \
+  /cruise-control/cruise-control/build/dependant-libs/cruise-control-metrics-reporter.jar
+
+FROM node:10.23
+RUN mkdir /src && cd /src && git clone https://github.com/amuraru/cruise-control-ui.git
+WORKDIR /src/cruise-control-ui
+RUN git fetch origin
+RUN git checkout master
+RUN git pull
+RUN git rev-parse HEAD
+RUN npm install
+RUN npm run build
+
+FROM openjdk:14.0.2-slim
+ARG SOURCE_REF
+ARG SOURCE_TYPE
+ARG DOCKERFILE_PATH
+ARG VERSION
+
+RUN mkdir -p /opt/cruise-control /opt/cruise-control/cruise-control-ui
+COPY --from=0 /cruise-control/cruise-control/build/libs/cruise-control.jar /opt/cruise-control/cruise-control/build/libs/cruise-control.jar
+COPY --from=0 /cruise-control/config /opt/cruise-control/config
+COPY --from=0 /cruise-control/kafka-cruise-control-start.sh /opt/cruise-control/
+COPY --from=0 /cruise-control/cruise-control/build/dependant-libs /opt/cruise-control/cruise-control/build/dependant-libs
+COPY docker/opt/cruise-control /opt/cruise-control/
+COPY --from=1 /src/cruise-control-ui/dist /opt/cruise-control/cruise-control-ui/dist
+RUN echo "local,localhost,/kafkacruisecontrol" > /opt/cruise-control/cruise-control-ui/dist/static/config.csv
+
+EXPOSE 8090
+CMD [ "/opt/cruise-control/start.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,18 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-debian-slim
+FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-debian-slim
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates
 RUN mkdir /cruise-control
 COPY . /cruise-control
 RUN cd cruise-control && echo && ./gradlew jar copyDependantLibs
 
+
+RUN ls -la /cruise-control/cruise-control/build/libs/cruise-control-*.jar
 RUN mv -v /cruise-control/cruise-control/build/libs/cruise-control-*.jar \
   /cruise-control/cruise-control/build/libs/cruise-control.jar
 RUN mv -v /cruise-control/cruise-control/build/dependant-libs/cruise-control-metrics-reporter-*.jar \
   /cruise-control/cruise-control/build/dependant-libs/cruise-control-metrics-reporter.jar
 
-FROM node:10.23
+FROM node:14.17.1-buster
 RUN mkdir /src && cd /src && git clone https://github.com/amuraru/cruise-control-ui.git
 WORKDIR /src/cruise-control-ui
 RUN git fetch origin
@@ -20,7 +22,7 @@ RUN git rev-parse HEAD
 RUN npm install
 RUN npm run build
 
-FROM openjdk:14.0.2-slim
+FROM azul/zulu-openjdk:16.0.1
 ARG SOURCE_REF
 ARG SOURCE_TYPE
 ARG DOCKERFILE_PATH

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,5 @@
+# Dockerfile to build Kafka CruiseControl
+
+This is based on [solsson/cruise-control](https://github.com/solsson/dockerfiles/tree/master/cruise-control) with the following additions:
+1. Use `openjdk 14`
+1. Builds Adobe maintained fork of cruise-control:https://github.com/adobe/cruise-control

--- a/docker/opt/cruise-control/config/log4j.properties
+++ b/docker/opt/cruise-control/config/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger = INFO, FILE
+
+log4j.appender.FILE=org.apache.log4j.FileAppender
+log4j.appender.FILE.File=/dev/stdout
+
+log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.FILE.layout.conversionPattern=[%d] %p %m (%c)%n

--- a/docker/opt/cruise-control/config/log4j2.xml
+++ b/docker/opt/cruise-control/config/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <File name="Console" fileName="/dev/stdout">
+            <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/docker/opt/cruise-control/start.sh
+++ b/docker/opt/cruise-control/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+cd /opt/cruise-control
+
+# Set heap memory settings for container environments
+if [ -z "$KAFKA_HEAP_OPTS" ]; then
+  export KAFKA_HEAP_OPTS="-XX:InitialRAMPercentage=30 -XX:MaxRAMPercentage=85"
+fi
+/bin/bash ${DEBUG:+-x} /opt/cruise-control/kafka-cruise-control-start.sh /opt/cruise-control/config/cruisecontrol.properties 8090

--- a/docker/opt/cruise-control/start.sh
+++ b/docker/opt/cruise-control/start.sh
@@ -6,4 +6,6 @@ cd /opt/cruise-control
 if [ -z "$KAFKA_HEAP_OPTS" ]; then
   export KAFKA_HEAP_OPTS="-XX:InitialRAMPercentage=30 -XX:MaxRAMPercentage=85"
 fi
+# disable JEP 396: Strongly Encapsulate JDK Internals by Default (JDK-8256299)
+export KAFKA_HEAP_OPTS="--illegal-access=permit ${KAFKA_HEAP_OPTS}"
 /bin/bash ${DEBUG:+-x} /opt/cruise-control/kafka-cruise-control-start.sh /opt/cruise-control/config/cruisecontrol.properties 8090

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
 kafkaVersion=2.7.0
-zookeeperVersion=3.5.8
+zookeeperVersion=3.6.3
 nettyVersion=4.1.63.Final
 jettyVersion=9.4.42.v20210604

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xms512m -Xmx512m
-kafkaVersion=2.7.0
+kafkaVersion=2.7.1
 zookeeperVersion=3.6.3
 nettyVersion=4.1.63.Final
 jettyVersion=9.4.42.v20210604


### PR DESCRIPTION
This PR resolves https://github.com/linkedin/cruise-control/issues/1264 

It seems that intra.broker.goals setting is checked at config validation only and this PR updates sanity check logic. 

Adding WIP label while testing in dev env.
