### PR TITLE
Add endpoint to move all replicas from a disk to another disk of the same broker

### DIFF
--- a/config/cruisecontrol.properties
+++ b/config/cruisecontrol.properties
@@ -170,6 +170,9 @@ num.proposal.precompute.threads=1
 # The impact of strictness on the relative balancedness score.
 #goal.balancedness.strictness.weight
 
+# the error margin between removed disk size and remaining disk size
+#remove.disks.remaining.size.error.margin=0.1
+
 # Configurations for the executor
 # =======================================
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
@@ -75,7 +75,11 @@ public class DiskRemovalGoal implements Goal {
             Set<Replica> replicasToMove = currentBroker.disk(logDirToRemove).replicas();
             while (!replicasToMove.isEmpty()) {
                 Replica replica = (Replica) replicasToMove.toArray()[0];
-                clusterModel.relocateReplica(replica.topicPartition(), brokerId, remainingDisks.get(removedLogDirsCount % remainingDisksNumber).logDir());
+                clusterModel.relocateReplica(
+                        replica.topicPartition(),
+                        brokerId,
+                        remainingDisks.get(removedLogDirsCount % remainingDisksNumber).logDir()
+                );
             }
             removedLogDirsCount++;
         }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
@@ -66,7 +66,6 @@ public class DiskRemovalGoal implements Goal {
             while (!logDirs.isEmpty()) {
                 String logDirToRemove = (String) logDirs.toArray()[0];
 
-                currentBroker.disk(logDirToRemove).setState(Disk.State.DEMOTED);
                 Set<Replica> replicasToMove = currentBroker.disk(logDirToRemove).replicas();
                 while (!replicasToMove.isEmpty()) {
                     Replica replica = (Replica) replicasToMove.toArray()[0];

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.goals;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingAction;
+import com.linkedin.kafka.cruisecontrol.analyzer.ProvisionResponse;
+import com.linkedin.kafka.cruisecontrol.analyzer.ProvisionStatus;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
+import com.linkedin.kafka.cruisecontrol.model.Disk;
+import com.linkedin.kafka.cruisecontrol.model.Replica;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
+
+import java.util.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.ACCEPT;
+import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.MIN_NUM_VALID_WINDOWS_FOR_SELF_HEALING;
+
+
+/**
+ * Soft goal to move the replicas to different log dir.
+ */
+public class DiskRemovalGoal implements Goal {
+    private static final Logger LOG = LoggerFactory.getLogger(DiskRemovalGoal.class);
+    private final ProvisionResponse _provisionResponse;
+
+    protected final Map<Integer, Set<String>> _brokerIdAndLogdirs;
+
+    public DiskRemovalGoal() {
+        this(Collections.emptyMap());
+    }
+
+    public DiskRemovalGoal(Map<Integer, Set<String>> brokerIdAndLogdirs) {
+        _provisionResponse = new ProvisionResponse(ProvisionStatus.UNDECIDED);
+        _brokerIdAndLogdirs = brokerIdAndLogdirs;
+    }
+
+    private void sanityCheckOptimizationOptions(OptimizationOptions optimizationOptions) {
+        if (optimizationOptions.isTriggeredByGoalViolation()) {
+            throw new IllegalArgumentException(String.format("%s goal does not support use by goal violation detector.", name()));
+        }
+    }
+
+    @Override
+    public boolean optimize(ClusterModel clusterModel, Set<Goal> optimizedGoals, OptimizationOptions optimizationOptions) {
+        sanityCheckOptimizationOptions(optimizationOptions);
+
+        for (Map.Entry<Integer, Set<String>> brokerIdLogDirs : _brokerIdAndLogdirs.entrySet()) {
+            Integer brokerId = brokerIdLogDirs.getKey();
+            Set<String> logDirs = brokerIdLogDirs.getValue();
+
+            Broker currentBroker = clusterModel.broker(brokerId);
+            List<Disk> remainingDisks = new ArrayList<>();
+            currentBroker.disks().stream().filter(disk -> !logDirs.contains(disk.logDir())).forEach(remainingDisks::add);
+
+            int step = 0;
+            int size = remainingDisks.size();
+            while (!logDirs.isEmpty()) {
+                String logDirToRemove = (String) logDirs.toArray()[0];
+
+                currentBroker.disk(logDirToRemove).setState(Disk.State.DEMOTED);
+                Set<Replica> replicasToMove = currentBroker.disk(logDirToRemove).replicas();
+                while (!replicasToMove.isEmpty()) {
+                    Replica replica = (Replica) replicasToMove.toArray()[0];
+                    clusterModel.relocateReplica(replica.topicPartition(), brokerId, remainingDisks.get(step % size).logDir());
+                }
+
+                logDirs.remove(logDirToRemove);
+                step++;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel) {
+        return ACCEPT;
+    }
+
+    @Override
+    public ClusterModelStatsComparator clusterModelStatsComparator() {
+        return new ClusterModelStatsComparator() {
+            @Override
+            public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+                return 0;
+            }
+
+            @Override
+            public String explainLastComparison() {
+                return String.format("Comparison for the %s is irrelevant.", name());
+            }
+        };
+    }
+
+    @Override
+    public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
+        return new ModelCompletenessRequirements(MIN_NUM_VALID_WINDOWS_FOR_SELF_HEALING, 0, true);
+    }
+
+    @Override
+    public String name() {
+        return DiskRemovalGoal.class.getSimpleName();
+    }
+
+    @Override
+    public void finish() {
+
+    }
+
+    @Override
+    public boolean isHardGoal() {
+        return false;
+    }
+
+    @Override
+    public ProvisionStatus provisionStatus() {
+        // Provision status computation is not relevant to PLE goal.
+        return provisionResponse().status();
+    }
+
+    @Override
+    public ProvisionResponse provisionResponse() {
+        return _provisionResponse;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
@@ -15,9 +15,11 @@ import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.model.Disk;
 import com.linkedin.kafka.cruisecontrol.model.Replica;
 import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
-
-import java.util.*;
-
+import java.util.Set;
+import java.util.Map;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/DiskRemovalGoal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol.analyzer.goals;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/AnalyzerConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/AnalyzerConfig.java
@@ -406,6 +406,15 @@ public final class AnalyzerConfig {
       + "Users can run goal optimizations in fast mode by setting the fast_mode parameter to true in relevant endpoints. "
       + "This mode intends to provide a more predictable runtime for goal optimizations.";
 
+  /**
+   * <code>remove.disks.remaining.size.error.margin</code>
+   */
+  public static final String REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN = "remove.disks.remaining.size.error.margin";
+  public static final double DEFAULT_REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN = 0.1;
+  public static final String REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN_DOC = "The margin of error between the remaining and the "
+      + "removed disk sizes. The ratio between the removed and the remaining size should be greater than this parameter. The minimum "
+      + "value is 0.05 (5%).";
+
   private AnalyzerConfig() {
   }
 
@@ -623,6 +632,12 @@ public final class AnalyzerConfig {
                             DEFAULT_FAST_MODE_PER_BROKER_MOVE_TIMEOUT_MS,
                             atLeast(1),
                             ConfigDef.Importance.LOW,
-                            FAST_MODE_PER_BROKER_MOVE_TIMEOUT_MS_DOC);
+                            FAST_MODE_PER_BROKER_MOVE_TIMEOUT_MS_DOC)
+                    .define(REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN,
+                            ConfigDef.Type.DOUBLE,
+                            DEFAULT_REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN,
+                            atLeast(0.05),
+                            ConfigDef.Importance.LOW,
+                            REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlParametersConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlParametersConfig.java
@@ -4,26 +4,7 @@
 
 package com.linkedin.kafka.cruisecontrol.config.constants;
 
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddBrokerParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.AdminParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.BootstrapParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.ClusterLoadParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlStateParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.DemoteBrokerParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.FixOfflineReplicasParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaClusterStateParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.PartitionLoadParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.PauseResumeParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.ProposalsParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.RebalanceParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveBrokerParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.ReviewBoardParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.ReviewParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.RightsizeParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.StopProposalParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.TopicConfigurationParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.TrainParameters;
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.UserTasksParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.*;
 import org.apache.kafka.common.config.ConfigDef;
 
 
@@ -179,6 +160,13 @@ public final class CruiseControlParametersConfig {
   public static final String DEFAULT_RIGHTSIZE_PARAMETERS_CLASS = RightsizeParameters.class.getName();
   public static final String RIGHTSIZE_PARAMETERS_CLASS_DOC = "The class for parameters of a provision rightsize request.";
 
+  /**
+   * <code>remove.disks.parameters.class</code>
+   */
+  public static final String REMOVE_DISKS_PARAMETERS_CLASS_CONFIG = "remove.disks.parameters.class";
+  public static final String DEFAULT_REMOVE_DISKS_PARAMETERS_CLASS = RemoveDisksParameters.class.getName();
+  public static final String REMOVE_DISKS_PARAMETERS_CLASS_DOC = "The class for parameters of a disks removal request.";
+
   private CruiseControlParametersConfig() {
   }
 
@@ -293,6 +281,11 @@ public final class CruiseControlParametersConfig {
                             ConfigDef.Type.CLASS,
                             DEFAULT_RIGHTSIZE_PARAMETERS_CLASS,
                             ConfigDef.Importance.MEDIUM,
-                            RIGHTSIZE_PARAMETERS_CLASS_DOC);
+                            RIGHTSIZE_PARAMETERS_CLASS_DOC)
+                    .define(REMOVE_DISKS_PARAMETERS_CLASS_CONFIG,
+                            ConfigDef.Type.CLASS,
+                            DEFAULT_REMOVE_DISKS_PARAMETERS_CLASS,
+                            ConfigDef.Importance.MEDIUM,
+                            REMOVE_DISKS_PARAMETERS_CLASS_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlParametersConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlParametersConfig.java
@@ -4,7 +4,27 @@
 
 package com.linkedin.kafka.cruisecontrol.config.constants;
 
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.*;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.PauseResumeParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.StopProposalParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.TrainParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.ClusterLoadParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.PartitionLoadParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.BootstrapParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.ProposalsParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.CruiseControlStateParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaClusterStateParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.UserTasksParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.ReviewBoardParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.ReviewParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddBrokerParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveBrokerParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.FixOfflineReplicasParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.DemoteBrokerParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RebalanceParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.AdminParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.TopicConfigurationParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RightsizeParameters;
 import org.apache.kafka.common.config.ConfigDef;
 
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlRequestConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlRequestConfig.java
@@ -4,7 +4,17 @@
 
 package com.linkedin.kafka.cruisecontrol.config.constants;
 
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.*;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.ClusterLoadRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.PartitionLoadRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.ProposalsRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.CruiseControlStateRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.TopicConfigurationRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.AddBrokerRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RemoveBrokerRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RemoveDisksRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.DemoteRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RebalanceRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.FixOfflineReplicasRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.RightsizeRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.AdminRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.BootstrapRequest;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlRequestConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlRequestConfig.java
@@ -4,17 +4,8 @@
 
 package com.linkedin.kafka.cruisecontrol.config.constants;
 
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.AddBrokerRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.ClusterLoadRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.CruiseControlStateRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.DemoteRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.FixOfflineReplicasRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.PartitionLoadRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.ProposalsRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RebalanceRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RemoveBrokerRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.*;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.RightsizeRequest;
-import com.linkedin.kafka.cruisecontrol.servlet.handler.async.TopicConfigurationRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.AdminRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.BootstrapRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.KafkaClusterStateRequest;
@@ -181,6 +172,13 @@ public final class CruiseControlRequestConfig {
   public static final String DEFAULT_RIGHTSIZE_REQUEST_CLASS = RightsizeRequest.class.getName();
   public static final String RIGHTSIZE_REQUEST_CLASS_DOC = "The class to handle a provision rightsize request.";
 
+  /**
+   * <code>remove.disks.request.class</code>
+   */
+  public static final String REMOVE_DISKS_REQUEST_CLASS_CONFIG = "remove.disks.request.class";
+  public static final String DEFAULT_REMOVE_DISKS_REQUEST_CLASS = RemoveDisksRequest.class.getName();
+  public static final String REMOVE_DISKS_REQUEST_CLASS_DOC = "The class to handle a disks removal request.";
+
   private CruiseControlRequestConfig() {
   }
 
@@ -295,6 +293,11 @@ public final class CruiseControlRequestConfig {
                             ConfigDef.Type.CLASS,
                             DEFAULT_RIGHTSIZE_REQUEST_CLASS,
                             ConfigDef.Importance.MEDIUM,
-                            RIGHTSIZE_REQUEST_CLASS_DOC);
+                            RIGHTSIZE_REQUEST_CLASS_DOC)
+                    .define(REMOVE_DISKS_REQUEST_CLASS_CONFIG,
+                            ConfigDef.Type.CLASS,
+                            DEFAULT_REMOVE_DISKS_REQUEST_CLASS,
+                            ConfigDef.Importance.MEDIUM,
+                            REMOVE_DISKS_REQUEST_CLASS_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/CruiseControlEndPoint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/CruiseControlEndPoint.java
@@ -34,7 +34,8 @@ public enum CruiseControlEndPoint implements EndPoint {
   ADMIN(CRUISE_CONTROL_ADMIN),
   REVIEW(CRUISE_CONTROL_ADMIN),
   TOPIC_CONFIGURATION(KAFKA_ADMIN),
-  RIGHTSIZE(KAFKA_ADMIN);
+  RIGHTSIZE(KAFKA_ADMIN),
+  REMOVE_DISKS(KAFKA_ADMIN);
 
   private static final List<CruiseControlEndPoint> CACHED_VALUES = List.of(values());
   private static final List<CruiseControlEndPoint> GET_ENDPOINTS = Arrays.asList(BOOTSTRAP,
@@ -57,7 +58,8 @@ public enum CruiseControlEndPoint implements EndPoint {
                                                                                   ADMIN,
                                                                                   REVIEW,
                                                                                   TOPIC_CONFIGURATION,
-                                                                                  RIGHTSIZE);
+                                                                                  RIGHTSIZE,
+                                                                                  REMOVE_DISKS);
 
   private final EndpointType _endpointType;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -114,6 +114,9 @@ public final class KafkaCruiseControlServletUtils {
     RequestParameterWrapper rightsize = new RequestParameterWrapper(RIGHTSIZE_PARAMETERS_CLASS_CONFIG,
                                                                     RIGHTSIZE_PARAMETER_OBJECT_CONFIG,
                                                                     RIGHTSIZE_REQUEST_CLASS_CONFIG);
+    RequestParameterWrapper removeDisks = new RequestParameterWrapper(REMOVE_DISKS_PARAMETERS_CLASS_CONFIG,
+                                                                      REMOVE_DISKS_PARAMETER_OBJECT_CONFIG,
+                                                                      REMOVE_DISKS_REQUEST_CLASS_CONFIG);
 
     requestParameterConfigs.put(BOOTSTRAP, bootstrap);
     requestParameterConfigs.put(TRAIN, train);
@@ -136,6 +139,7 @@ public final class KafkaCruiseControlServletUtils {
     requestParameterConfigs.put(REVIEW_BOARD, reviewBoard);
     requestParameterConfigs.put(TOPIC_CONFIGURATION, topicConfiguration);
     requestParameterConfigs.put(RIGHTSIZE, rightsize);
+    requestParameterConfigs.put(REMOVE_DISKS, removeDisks);
 
     REQUEST_PARAMETER_CONFIGS = Collections.unmodifiableMap(requestParameterConfigs);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveDisksRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveDisksRequest.java
@@ -1,0 +1,43 @@
+package com.linkedin.kafka.cruisecontrol.servlet.handler.async;
+
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.OperationFuture;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RemoveDisksRunnable;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
+
+import java.util.Map;
+
+import static com.linkedin.cruisecontrol.common.utils.Utils.validateNotNull;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.REMOVE_DISKS_PARAMETER_OBJECT_CONFIG;
+
+public class RemoveDisksRequest extends AbstractAsyncRequest {
+    protected RemoveDisksParameters _parameters;
+
+    public RemoveDisksRequest() {
+        super();
+    }
+
+    @Override
+    protected OperationFuture handle(String uuid) {
+        OperationFuture future = new OperationFuture("Remove disks");
+        pending(future.operationProgress());
+        _asyncKafkaCruiseControl.sessionExecutor().submit(new RemoveDisksRunnable(_asyncKafkaCruiseControl, future, _parameters, uuid));
+        return future;
+    }
+
+    @Override
+    public RemoveDisksParameters parameters() {
+        return _parameters;
+    }
+
+    @Override
+    public String name() {
+        return RemoveDisksRequest.class.getSimpleName();
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        super.configure(configs);
+        _parameters = (RemoveDisksParameters) validateNotNull(configs.get(REMOVE_DISKS_PARAMETER_OBJECT_CONFIG),
+                "Parameter configuration is missing from the request.");
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveDisksRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveDisksRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol.servlet.handler.async;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveDisksRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RemoveDisksRequest.java
@@ -1,9 +1,12 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
 package com.linkedin.kafka.cruisecontrol.servlet.handler.async;
 
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.OperationFuture;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RemoveDisksRunnable;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
-
 import java.util.Map;
 
 import static com.linkedin.cruisecontrol.common.utils.Utils.validateNotNull;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.*;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL;
@@ -114,6 +115,10 @@ public class RemoveDisksRunnable extends GoalBasedOperationRunnable {
             Integer brokerId = entry.getKey();
             Set<String> logDirs = entry.getValue();
             Broker broker = clusterModel.broker(brokerId);
+            Set<String> brokerLogDirs = broker.disks().stream().map(Disk::logDir).collect(Collectors.toSet());
+            if (brokerLogDirs.containsAll(logDirs)) {
+                throw new IllegalArgumentException(String.format("Invalid log dirs provided for broker %d.", brokerId));
+            }
             if (broker.disks().size() < logDirs.size()) {
                 throw new IllegalArgumentException(String.format("Invalid log dirs provided for broker %d.", brokerId));
             } else if (broker.disks().size() == logDirs.size()) {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
 package com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable;
 
 import com.linkedin.cruisecontrol.exception.NotEnoughValidWindowsException;
@@ -14,8 +18,12 @@ import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters
 import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
+import java.util.Set;
+import java.util.Map;
+import java.util.List;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
@@ -128,18 +128,20 @@ public class RemoveDisksRunnable extends GoalBasedOperationRunnable {
     }
 
     private void checkCanRemoveDisks(Map<Integer, Set<String>> brokerIdAndLogdirs, ClusterModel clusterModel) {
-        for (Integer brokerId : brokerIdAndLogdirs.keySet()) {
+        for (Map.Entry<Integer, Set<String>> entry : brokerIdAndLogdirs.entrySet()) {
+            Integer brokerId = entry.getKey();
+            Set<String> logDirs = entry.getValue();
             Broker broker = clusterModel.broker(brokerId);
-            if (broker.disks().size() < brokerIdAndLogdirs.get(brokerId).size()) {
+            if (broker.disks().size() < logDirs.size()) {
                 throw new IllegalArgumentException(String.format("Invalid log dirs provided for broker %d.", brokerId));
-            } else if (broker.disks().size() == brokerIdAndLogdirs.get(brokerId).size()) {
+            } else if (broker.disks().size() == logDirs.size()) {
                 throw new IllegalArgumentException(String.format("No log dir remaining to move replicas to for broker %d.", brokerId));
             }
 
             double removedCapacity = 0.0;
             double remainingCapacity = 0.0;
             for (Disk disk : broker.disks()) {
-                if (brokerIdAndLogdirs.get(brokerId).contains(disk.logDir())) {
+                if (logDirs.contains(disk.logDir())) {
                     removedCapacity += disk.capacity();
                 } else {
                     remainingCapacity += disk.capacity();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
@@ -1,0 +1,155 @@
+package com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable;
+
+import com.linkedin.cruisecontrol.exception.NotEnoughValidWindowsException;
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizerResult;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskRemovalGoal;
+import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
+import com.linkedin.kafka.cruisecontrol.exception.KafkaCruiseControlException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.Disk;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.response.OptimizationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.*;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL;
+
+public class RemoveDisksRunnable extends GoalBasedOperationRunnable {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveDisksRunnable.class);
+    protected final Map<Integer, Set<String>> _brokerIdAndLogdirs;
+
+    /**
+     * Constructor to be used for creating a runnable for self-healing.
+     */
+    public RemoveDisksRunnable(KafkaCruiseControl kafkaCruiseControl,
+                               List<String> selfHealingGoals,
+                               boolean allowCapacityEstimation,
+                               boolean excludeRecentlyDemotedBrokers,
+                               boolean excludeRecentlyRemovedBrokers,
+                               String anomalyId,
+                               Supplier<String> reasonSupplier,
+                               boolean stopOngoingExecution) {
+        super(kafkaCruiseControl, new OperationFuture("Broker Removal for Self-Healing"), selfHealingGoals, allowCapacityEstimation,
+                excludeRecentlyDemotedBrokers, excludeRecentlyRemovedBrokers, anomalyId, reasonSupplier, stopOngoingExecution);
+        _brokerIdAndLogdirs = Collections.emptyMap();
+    }
+
+    public RemoveDisksRunnable(KafkaCruiseControl kafkaCruiseControl,
+                               OperationFuture future,
+                               RemoveDisksParameters parameters,
+                               String uuid) {
+        super(kafkaCruiseControl, future, parameters, parameters.dryRun(), parameters.stopOngoingExecution(), parameters.skipHardGoalCheck(),
+                uuid, parameters::reason);
+        _brokerIdAndLogdirs = parameters.brokerIdAndLogdirs();
+    }
+
+    @Override
+    protected OptimizationResult getResult() throws Exception {
+        return new OptimizationResult(computeResult(), _kafkaCruiseControl.config());
+    }
+
+    @Override
+    protected void init() {
+        _kafkaCruiseControl.sanityCheckDryRun(_dryRun, _stopOngoingExecution);
+        _goalsByPriority = new ArrayList<>(1);
+        _goalsByPriority.add(new DiskRemovalGoal(_brokerIdAndLogdirs));
+
+        _operationProgress = _future.operationProgress();
+        if (_stopOngoingExecution) {
+            maybeStopOngoingExecutionToModifyAndWait(_kafkaCruiseControl, _operationProgress);
+        }
+        _combinedCompletenessRequirements = _goalsByPriority.get(0).clusterModelCompletenessRequirements();
+    }
+
+    @Override
+    protected OptimizerResult workWithClusterModel() throws KafkaCruiseControlException, NotEnoughValidWindowsException, TimeoutException {
+        Set<Integer> brokersToCheckPresence = new HashSet<>(_brokerIdAndLogdirs.keySet());
+        _kafkaCruiseControl.sanityCheckBrokerPresence(brokersToCheckPresence);
+        ClusterModel clusterModel = _kafkaCruiseControl.clusterModel(
+                DEFAULT_START_TIME_FOR_CLUSTER_MODEL,
+                _kafkaCruiseControl.timeMs(),
+                _combinedCompletenessRequirements,
+                true,
+                _allowCapacityEstimation,
+                _operationProgress
+        );
+
+        checkCanRemoveDisks(_brokerIdAndLogdirs, clusterModel);
+
+        OptimizationOptions optimizationOptions = computeOptimizationOptions(clusterModel,
+                false,
+                _kafkaCruiseControl,
+                Collections.emptySet(),
+                _dryRun,
+                _excludeRecentlyDemotedBrokers,
+                _excludeRecentlyRemovedBrokers,
+                _excludedTopics,
+                Collections.emptySet(),
+                false,
+                _fastMode
+        );
+
+        OptimizerResult result = _kafkaCruiseControl.optimizations(clusterModel, _goalsByPriority, _operationProgress, null, optimizationOptions);
+        if (!_dryRun) {
+            _kafkaCruiseControl.executeProposals(
+                    result.goalProposals(),
+                    Collections.emptySet(),
+                    isKafkaAssignerMode(_goals),
+                    0,
+                    0,
+                    1,
+                    1,
+                    SELF_HEALING_EXECUTION_PROGRESS_CHECK_INTERVAL_MS,
+                    SELF_HEALING_REPLICA_MOVEMENT_STRATEGY,
+                    _kafkaCruiseControl.config().getLong(ExecutorConfig.DEFAULT_REPLICATION_THROTTLE_CONFIG),
+                    _isTriggeredByUserRequest,
+                    _uuid,
+                    false
+            );
+        }
+
+        return result;
+    }
+
+    private void checkCanRemoveDisks(Map<Integer, Set<String>> brokerIdAndLogdirs, ClusterModel clusterModel) {
+        for (Integer brokerId : brokerIdAndLogdirs.keySet()) {
+            Broker broker = clusterModel.broker(brokerId);
+            if (broker.disks().size() < brokerIdAndLogdirs.get(brokerId).size()) {
+                throw new IllegalArgumentException(String.format("Invalid log dirs provided for broker %d.", brokerId));
+            } else if (broker.disks().size() == brokerIdAndLogdirs.get(brokerId).size()) {
+                throw new IllegalArgumentException(String.format("No log dir remaining to move replicas to for broker %d.", brokerId));
+            }
+
+            double removedCapacity = 0.0;
+            double remainingCapacity = 0.0;
+            for (Disk disk : broker.disks()) {
+                if (brokerIdAndLogdirs.get(brokerId).contains(disk.logDir())) {
+                    removedCapacity += disk.capacity();
+                } else {
+                    remainingCapacity += disk.capacity();
+                }
+            }
+            if (removedCapacity > remainingCapacity) {
+                throw new IllegalArgumentException("Not enough remaining capacity to move replicas to.");
+            }
+        }
+    }
+
+    @Override
+    protected boolean shouldWorkWithClusterModel() {
+        return true;
+    }
+
+    @Override
+    protected OptimizerResult workWithoutClusterModel() {
+        return null;
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RemoveDisksRunnable.java
@@ -20,12 +20,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Set;
 import java.util.Map;
-import java.util.List;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.ArrayList;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RunnableUtils.*;
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.DEFAULT_START_TIME_FOR_CLUSTER_MODEL;
@@ -33,22 +31,6 @@ import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils
 public class RemoveDisksRunnable extends GoalBasedOperationRunnable {
     private static final Logger LOG = LoggerFactory.getLogger(RemoveDisksRunnable.class);
     protected final Map<Integer, Set<String>> _brokerIdAndLogdirs;
-
-    /**
-     * Constructor to be used for creating a runnable for self-healing.
-     */
-    public RemoveDisksRunnable(KafkaCruiseControl kafkaCruiseControl,
-                               List<String> selfHealingGoals,
-                               boolean allowCapacityEstimation,
-                               boolean excludeRecentlyDemotedBrokers,
-                               boolean excludeRecentlyRemovedBrokers,
-                               String anomalyId,
-                               Supplier<String> reasonSupplier,
-                               boolean stopOngoingExecution) {
-        super(kafkaCruiseControl, new OperationFuture("Broker Removal for Self-Healing"), selfHealingGoals, allowCapacityEstimation,
-                excludeRecentlyDemotedBrokers, excludeRecentlyRemovedBrokers, anomalyId, reasonSupplier, stopOngoingExecution);
-        _brokerIdAndLogdirs = Collections.emptyMap();
-    }
 
     public RemoveDisksRunnable(KafkaCruiseControl kafkaCruiseControl,
                                OperationFuture future,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -161,6 +161,7 @@ public final class ParameterUtils {
   public static final String REVIEW_PARAMETER_OBJECT_CONFIG = "review.parameter.object";
   public static final String TOPIC_CONFIGURATION_PARAMETER_OBJECT_CONFIG = "topic.configuration.parameter.object";
   public static final String RIGHTSIZE_PARAMETER_OBJECT_CONFIG = "rightsize.parameter.object";
+  public static final String REMOVE_DISKS_PARAMETER_OBJECT_CONFIG = "remove.disks.parameter.object";
 
   private ParameterUtils() {
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
@@ -24,7 +24,6 @@ public class RemoveDisksParameters extends GoalBasedOptimizationParameters {
         validParameterNames.add(REASON_PARAM);
         validParameterNames.add(SKIP_HARD_GOAL_CHECK_PARAM);
         validParameterNames.add(STOP_ONGOING_EXECUTION_PARAM);
-        validParameterNames.addAll(GoalBasedOptimizationParameters.CASE_INSENSITIVE_PARAMETER_NAMES);
         CASE_INSENSITIVE_PARAMETER_NAMES = Collections.unmodifiableSortedSet(validParameterNames);
     }
     protected boolean _dryRun;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
@@ -1,0 +1,72 @@
+package com.linkedin.kafka.cruisecontrol.servlet.parameters;
+
+import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
+import com.linkedin.kafka.cruisecontrol.servlet.UserRequestException;
+
+import java.io.UnsupportedEncodingException;
+import java.util.*;
+
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.*;
+
+public class RemoveDisksParameters extends GoalBasedOptimizationParameters {
+    protected static final SortedSet<String> CASE_INSENSITIVE_PARAMETER_NAMES;
+    static {
+        SortedSet<String> validParameterNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        validParameterNames.add(BROKER_ID_AND_LOGDIRS_PARAM);
+        validParameterNames.add(DRY_RUN_PARAM);
+        validParameterNames.add(REASON_PARAM);
+        validParameterNames.add(SKIP_HARD_GOAL_CHECK_PARAM);
+        validParameterNames.add(STOP_ONGOING_EXECUTION_PARAM);
+        validParameterNames.addAll(GoalBasedOptimizationParameters.CASE_INSENSITIVE_PARAMETER_NAMES);
+        CASE_INSENSITIVE_PARAMETER_NAMES = Collections.unmodifiableSortedSet(validParameterNames);
+    }
+    protected boolean _dryRun;
+    protected boolean _skipHardGoalCheck;
+    protected String _reason;
+    protected boolean _stopOngoingExecution;
+    protected Map<Integer, Set<String>> _logdirByBrokerId;
+
+    public RemoveDisksParameters() {
+        super();
+    }
+
+    @Override
+    protected void initParameters() throws UnsupportedEncodingException {
+        super.initParameters();
+        _logdirByBrokerId = ParameterUtils.brokerIdAndLogdirs(_request);
+        _dryRun = ParameterUtils.getDryRun(_request);
+        _skipHardGoalCheck = ParameterUtils.skipHardGoalCheck(_request);
+        boolean requestReasonRequired = _config.getBoolean(ExecutorConfig.REQUEST_REASON_REQUIRED_CONFIG);
+        _reason = ParameterUtils.reason(_request, requestReasonRequired && !_dryRun);
+        _stopOngoingExecution = ParameterUtils.stopOngoingExecution(_request);
+        if (_stopOngoingExecution && _dryRun) {
+            throw new UserRequestException(String.format("%s and %s cannot both be set to true.", STOP_ONGOING_EXECUTION_PARAM, DRY_RUN_PARAM));
+        }
+    }
+
+    public Map<Integer, Set<String>> brokerIdAndLogdirs() {
+        return _logdirByBrokerId;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        super.configure(configs);
+    }
+
+    @Override
+    public SortedSet<String> caseInsensitiveParameterNames() {
+        return CASE_INSENSITIVE_PARAMETER_NAMES;
+    }
+    public String reason() {
+        return _reason;
+    }
+    public boolean dryRun() {
+        return _dryRun;
+    }
+    public boolean skipHardGoalCheck() {
+        return _skipHardGoalCheck;
+    }
+    public boolean stopOngoingExecution() {
+        return _stopOngoingExecution;
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
@@ -1,10 +1,17 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;
 
 import com.linkedin.kafka.cruisecontrol.config.constants.ExecutorConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.UserRequestException;
-
 import java.io.UnsupportedEncodingException;
-import java.util.*;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.Collections;
+import java.util.Set;
+import java.util.Map;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.*;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RemoveDisksParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 
 package com.linkedin.kafka.cruisecontrol.servlet.parameters;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/OptimizationResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/OptimizationResult.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +87,8 @@ public class OptimizationResult extends AbstractCruiseControlResponse {
       case TOPIC_CONFIGURATION:
         return String.format("%n%nCluster load after updating replication factor of topics %s%n",
                              _optimizerResult.topicsWithReplicationFactorChange());
+      case REMOVE_DISKS:
+        return String.format("%n%nCluster load after removing disks %s:%n", ((RemoveDisksParameters) parameters).brokerIdAndLogdirs());
       default:
         LOG.error("Unrecognized endpoint.");
         return "Unrecognized endpoint.";

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/OptimizationResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/OptimizationResult.java
@@ -6,22 +6,21 @@ package com.linkedin.kafka.cruisecontrol.servlet.response;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import com.linkedin.kafka.cruisecontrol.analyzer.OptimizerResult;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.ExecutionProposal;
 import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
 import com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.AddedOrRemovedBrokerParameters;
-import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.DemoteBrokerParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.KafkaOptimizationParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveDisksParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DiskRemovalGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DiskRemovalGoalTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer;
+
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.AggregatedMetricValues;
+import com.linkedin.cruisecontrol.monitor.sampling.aggregator.MetricValues;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskRemovalGoal;
+import com.linkedin.kafka.cruisecontrol.common.Resource;
+import com.linkedin.kafka.cruisecontrol.common.TestConstants;
+import com.linkedin.kafka.cruisecontrol.config.BrokerCapacityInfo;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelGeneration;
+import com.linkedin.kafka.cruisecontrol.monitor.metricdefinition.KafkaMetricDef;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+import java.util.Collections;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
+
+import static com.linkedin.kafka.cruisecontrol.common.TestConstants.*;
+import static org.junit.Assert.assertEquals;
+
+public class DiskRemovalGoalTest {
+    private static final TopicPartition T0P0 = new TopicPartition(TOPIC0, 0);
+    private static final TopicPartition T0P1 = new TopicPartition(TOPIC0, 1);
+
+    @Test
+    public void testMoveReplicasToAnotherLogDir() {
+        ClusterModel clusterModel = createClusterModel();
+        Map<Integer, Set<String>> brokerIdAndLogDirs = new HashMap<>();
+        brokerIdAndLogDirs.put(0, new HashSet<>(Arrays.asList(LOGDIR0)));
+
+        DiskRemovalGoal goal = new DiskRemovalGoal(brokerIdAndLogDirs);
+        // Before the optimization, goals are expected to be undecided wrt their provision status.
+        assertEquals(ProvisionStatus.UNDECIDED, goal.provisionResponse().status());
+        goal.optimize(clusterModel, Collections.emptySet(), new OptimizationOptions(Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet()));
+        // After the optimization, PreferredLeaderElectionGoal is expected to be undecided wrt its provision status.
+        assertEquals(ProvisionStatus.UNDECIDED, goal.provisionResponse().status());
+
+        assertEquals(clusterModel.broker(0).disk(LOGDIR0).replicas().size(), 0);
+    }
+
+    private ClusterModel createClusterModel() {
+        boolean populateDiskInfo = true;
+        String rack = "r0";
+        String host = "h0";
+        int brokerId = 0;
+        int index = 0;
+
+        ClusterModel clusterModel = new ClusterModel(new ModelGeneration(0, 0),
+                1.0);
+
+        clusterModel.createRack(rack);
+
+        BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY,
+                null,
+                TestConstants.DISK_CAPACITY);
+        clusterModel.createBroker(rack, host, brokerId, commonBrokerCapacityInfo, populateDiskInfo);
+
+        createReplicaAndSetLoad(clusterModel, rack, brokerId, LOGDIR0, T0P0, index, true);
+        createReplicaAndSetLoad(clusterModel, rack, brokerId, LOGDIR1, T0P1, index, false);
+        return clusterModel;
+    }
+
+    private void createReplicaAndSetLoad(ClusterModel clusterModel,
+                                         String rack,
+                                         int brokerId,
+                                         String logdir,
+                                         TopicPartition tp,
+                                         int index,
+                                         boolean isLeader) {
+        clusterModel.createReplica(rack, brokerId, tp, index, isLeader, false, logdir, false);
+        MetricValues metricValues = new MetricValues(1);
+        Map<Short, MetricValues> metricValuesByResource = new HashMap<>();
+        Resource.cachedValues().forEach(r -> {
+            for (short id : KafkaMetricDef.resourceToMetricIds(r)) {
+                metricValuesByResource.put(id, metricValues);
+            }
+        });
+        clusterModel.setReplicaLoad(rack, brokerId, tp, new AggregatedMetricValues(metricValuesByResource),
+                Collections.singletonList(1L));
+    }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DiskRemovalGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DiskRemovalGoalTest.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
-import java.util.Arrays;
 import java.util.Collections;
 
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.*;
@@ -29,31 +28,82 @@ import static org.junit.Assert.assertEquals;
 public class DiskRemovalGoalTest {
     private static final TopicPartition T0P0 = new TopicPartition(TOPIC0, 0);
     private static final TopicPartition T0P1 = new TopicPartition(TOPIC0, 1);
+    private static final boolean POPULATE_DISK_INFO = true;
+    private static final String RACK = "r0";
+    private static final String HOST = "h0";
+    private static final int BROKER_ID = 0;
+    private static final int INDEX = 0;
+    private static final double HIGH_DISK_USAGE = 0.8;
+    private static final double LOW_DISK_USAGE = 0.3;
+    private static final double MEDIUM_DISK_USAGE = 0.5;
+    private static final double NO_DISK_USAGE = 0;
 
     @Test
     public void testMoveReplicasToAnotherLogDir() {
-        ClusterModel clusterModel = createClusterModel(false);
+        ClusterModel clusterModel = createClusterModel();
+        createReplicaAndSetLoad(clusterModel, LOGDIR0, T0P0, true, LOW_DISK_USAGE);
+        createReplicaAndSetLoad(clusterModel, LOGDIR1, T0P1, false, LOW_DISK_USAGE);
         Map<Integer, Set<String>> brokerIdAndLogDirs = new HashMap<>();
-        brokerIdAndLogDirs.put(0, new HashSet<>(Arrays.asList(LOGDIR0)));
+        brokerIdAndLogDirs.put(0, new HashSet<>(Collections.singletonList(LOGDIR0)));
 
-        DiskRemovalGoal goal = new DiskRemovalGoal(brokerIdAndLogDirs, DEFAULT_REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN);
-        // Before the optimization, goals are expected to be undecided wrt their provision status.
-        assertEquals(ProvisionStatus.UNDECIDED, goal.provisionResponse().status());
-        goal.optimize(clusterModel, Collections.emptySet(), new OptimizationOptions(Collections.emptySet(),
-                Collections.emptySet(),
-                Collections.emptySet()));
-        // After the optimization, PreferredLeaderElectionGoal is expected to be undecided wrt its provision status.
-        assertEquals(ProvisionStatus.UNDECIDED, goal.provisionResponse().status());
+        runOptimization(clusterModel, brokerIdAndLogDirs);
 
         assertEquals(clusterModel.broker(0).disk(LOGDIR0).replicas().size(), 0);
     }
 
     @Test
-    public void testReplicaStaysIfDiskUtilizationIsHigh() {
-        ClusterModel clusterModel = createClusterModel(true);
+    public void testMoveReplicasToAlreadyUsedDisk() {
+        ClusterModel clusterModel = createClusterModel();
+        createReplicaAndSetLoad(clusterModel, LOGDIR0, T0P0, true, LOW_DISK_USAGE);
+        createReplicaAndSetLoad(clusterModel, LOGDIR1, T0P1, false, MEDIUM_DISK_USAGE);
         Map<Integer, Set<String>> brokerIdAndLogDirs = new HashMap<>();
-        brokerIdAndLogDirs.put(0, new HashSet<>(Arrays.asList(LOGDIR0)));
+        brokerIdAndLogDirs.put(0, new HashSet<>(Collections.singletonList(LOGDIR0)));
 
+        runOptimization(clusterModel, brokerIdAndLogDirs);
+
+        assertEquals(clusterModel.broker(0).disk(LOGDIR0).replicas().size(), 0);
+    }
+
+    @Test
+    public void testMoveLargeDiskToEmptyDisk() {
+        ClusterModel clusterModel = createClusterModel();
+        createReplicaAndSetLoad(clusterModel, LOGDIR0, T0P0, true, HIGH_DISK_USAGE);
+        createReplicaAndSetLoad(clusterModel, LOGDIR1, T0P1, false, NO_DISK_USAGE);
+        Map<Integer, Set<String>> brokerIdAndLogDirs = new HashMap<>();
+        brokerIdAndLogDirs.put(0, new HashSet<>(Collections.singletonList(LOGDIR0)));
+
+        runOptimization(clusterModel, brokerIdAndLogDirs);
+
+        assertEquals(clusterModel.broker(0).disk(LOGDIR0).replicas().size(), 0);
+    }
+
+    @Test
+    public void testReplicasStayIsDestinationHasInsufficientCapacity() {
+        ClusterModel clusterModel = createClusterModel();
+        createReplicaAndSetLoad(clusterModel, LOGDIR0, T0P0, true, MEDIUM_DISK_USAGE);
+        createReplicaAndSetLoad(clusterModel, LOGDIR1, T0P1, false, MEDIUM_DISK_USAGE);
+        Map<Integer, Set<String>> brokerIdAndLogDirs = new HashMap<>();
+        brokerIdAndLogDirs.put(0, new HashSet<>(Collections.singletonList(LOGDIR0)));
+
+        runOptimization(clusterModel, brokerIdAndLogDirs);
+
+        assertEquals(clusterModel.broker(0).disk(LOGDIR0).replicas().size(), 1);
+    }
+
+    @Test
+    public void testReplicasStayIfDiskAlmostFull() {
+        ClusterModel clusterModel = createClusterModel();
+        createReplicaAndSetLoad(clusterModel, LOGDIR0, T0P0, true, LOW_DISK_USAGE);
+        createReplicaAndSetLoad(clusterModel, LOGDIR1, T0P1, false, HIGH_DISK_USAGE);
+        Map<Integer, Set<String>> brokerIdAndLogDirs = new HashMap<>();
+        brokerIdAndLogDirs.put(0, new HashSet<>(Collections.singletonList(LOGDIR0)));
+
+        runOptimization(clusterModel, brokerIdAndLogDirs);
+
+        assertEquals(clusterModel.broker(0).disk(LOGDIR0).replicas().size(), 1);
+    }
+
+    private void runOptimization(ClusterModel clusterModel, Map<Integer, Set<String>> brokerIdAndLogDirs) {
         DiskRemovalGoal goal = new DiskRemovalGoal(brokerIdAndLogDirs, DEFAULT_REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN);
         // Before the optimization, goals are expected to be undecided wrt their provision status.
         assertEquals(ProvisionStatus.UNDECIDED, goal.provisionResponse().status());
@@ -62,44 +112,24 @@ public class DiskRemovalGoalTest {
                 Collections.emptySet()));
         // After the optimization, PreferredLeaderElectionGoal is expected to be undecided wrt its provision status.
         assertEquals(ProvisionStatus.UNDECIDED, goal.provisionResponse().status());
-
-        assertEquals(clusterModel.broker(0).disk(LOGDIR0).replicas().size(), 1);
     }
 
-    private ClusterModel createClusterModel(boolean hasHighDiskUsage) {
-        boolean populateDiskInfo = true;
-        String rack = "r0";
-        String host = "h0";
-        int brokerId = 0;
-        int index = 0;
-
-        ClusterModel clusterModel = new ClusterModel(new ModelGeneration(0, 0),
-                1.0);
-
-        clusterModel.createRack(rack);
-
-        BrokerCapacityInfo commonBrokerCapacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY,
-                null,
-                TestConstants.DISK_CAPACITY);
-        clusterModel.createBroker(rack, host, brokerId, commonBrokerCapacityInfo, populateDiskInfo);
-
-        createReplicaAndSetLoad(clusterModel, rack, brokerId, LOGDIR0, T0P0, index, true, hasHighDiskUsage);
-        createReplicaAndSetLoad(clusterModel, rack, brokerId, LOGDIR1, T0P1, index, false, hasHighDiskUsage);
+    private ClusterModel createClusterModel() {
+        ClusterModel clusterModel = new ClusterModel(new ModelGeneration(0, 0), 1.0);
+        clusterModel.createRack(RACK);
+        BrokerCapacityInfo capacityInfo = new BrokerCapacityInfo(TestConstants.BROKER_CAPACITY, null, TestConstants.DISK_CAPACITY);
+        clusterModel.createBroker(RACK, HOST, BROKER_ID, capacityInfo, POPULATE_DISK_INFO);
         return clusterModel;
     }
 
     private void createReplicaAndSetLoad(ClusterModel clusterModel,
-                                         String rack,
-                                         int brokerId,
                                          String logdir,
                                          TopicPartition tp,
-                                         int index,
                                          boolean isLeader,
-                                         boolean hasHighDiskUsage) {
-        clusterModel.createReplica(rack, brokerId, tp, index, isLeader, false, logdir, false);
+                                         double diskUsage) {
+        clusterModel.createReplica(RACK, BROKER_ID, tp, INDEX, isLeader, false, logdir, false);
         MetricValues defaultMetricValues = new MetricValues(1);
         MetricValues diskMetricValues = new MetricValues(1);
-        double diskUsage = hasHighDiskUsage ? 0.8 : 0.3;
         double[] diskMetric = {DISK_CAPACITY.get(logdir) * diskUsage};
         diskMetricValues.add(diskMetric);
         Map<Short, MetricValues> metricValuesByResource = new HashMap<>();
@@ -112,7 +142,7 @@ public class DiskRemovalGoalTest {
                 }
             }
         });
-        clusterModel.setReplicaLoad(rack, brokerId, tp, new AggregatedMetricValues(metricValuesByResource),
+        clusterModel.setReplicaLoad(RACK, BROKER_ID, tp, new AggregatedMetricValues(metricValuesByResource),
                 Collections.singletonList(1L));
     }
 }

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DiskRemovalGoalTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DiskRemovalGoalTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 import static com.linkedin.kafka.cruisecontrol.common.TestConstants.*;
+import static com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig.DEFAULT_REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN;
 import static org.junit.Assert.assertEquals;
 
 public class DiskRemovalGoalTest {
@@ -35,7 +36,7 @@ public class DiskRemovalGoalTest {
         Map<Integer, Set<String>> brokerIdAndLogDirs = new HashMap<>();
         brokerIdAndLogDirs.put(0, new HashSet<>(Arrays.asList(LOGDIR0)));
 
-        DiskRemovalGoal goal = new DiskRemovalGoal(brokerIdAndLogDirs);
+        DiskRemovalGoal goal = new DiskRemovalGoal(brokerIdAndLogDirs, DEFAULT_REMOVE_DISKS_REMAINING_SIZE_ERROR_MARGIN);
         // Before the optimization, goals are expected to be undecided wrt their provision status.
         assertEquals(ProvisionStatus.UNDECIDED, goal.provisionResponse().status());
         goal.optimize(clusterModel, Collections.emptySet(), new OptimizationOptions(Collections.emptySet(),

--- a/cruise-control/src/yaml/base.yaml
+++ b/cruise-control/src/yaml/base.yaml
@@ -46,3 +46,5 @@ paths:
     $ref: 'endpoints/train.yaml#/TrainEndpoint'
   /kafkacruisecontrol/user_tasks:
     $ref: 'endpoints/userTasks.yaml#/UserTasksEndpoint'
+  /kafkacruisecontrol/remove_disks:
+    $ref: 'endpoints/removeDisks.yaml#/RemoveDisksEndpoint'

--- a/cruise-control/src/yaml/endpoints/removeDisks.yaml
+++ b/cruise-control/src/yaml/endpoints/removeDisks.yaml
@@ -1,7 +1,7 @@
 RemoveDisksEndpoint:
   post:
     operationId: removeDisks
-    summary: Move all replicas from the specified disk to another disk of the same broker.
+    summary: Move all replicas from the specified disk to other disks of the same broker.
     parameters:
       - name: dryrun
         in: query

--- a/cruise-control/src/yaml/endpoints/removeDisks.yaml
+++ b/cruise-control/src/yaml/endpoints/removeDisks.yaml
@@ -1,0 +1,141 @@
+RemoveDisksEndpoint:
+  post:
+    operationId: removeDisks
+    summary: Move all replicas from the specified disk to another disk of the same broker.
+    parameters:
+      - name: dryrun
+        in: query
+        description: Whether to dry-run the request or not.
+        schema:
+          type: boolean
+          default: true
+      - name: goals
+        in: query
+        description: List of goals used to generate proposal, the default goals will be used if this parameter is not specified.
+        schema:
+          type: array
+          items:
+            type: string
+          example: ["RackAwareGoal", "ReplicaCapacityGoal", "ReplicaDistributionGoal"]
+      - name: allow_capacity_estimation
+        in: query
+        description: Whether to allow capacity estimation when cruise-control is unable to obtain all per-broker capacity information.
+        schema:
+          type: boolean
+          default: false
+      - name: stop_ongoing_execution
+        in: query
+        description: Whether to stop the ongoing execution (if any) and start executing the given request.
+        schema:
+          type: boolean
+          default: false
+      - name: fast_mode
+        in: query
+        description: True to compute proposals in fast mode, false otherwise
+        schema:
+          type: boolean
+          default: true
+      - name: reason
+        in: query
+        description: Reason for request.
+        schema:
+          type: string
+        example: "Balance disk utilization across all brokers in the cluster."
+      - name: brokerid_and_logdirs
+        in: query
+        description: List of broker id and logdir pair to be demoted in the cluster.
+        schema:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+      - name: data_from
+        in: query
+        description: Whether to calculate proposal from available valid partitions or valid windows.
+        schema:
+          type: string
+          default: VALID_WINDOWS
+      - name: doAs
+        in: query
+        description: The user specified by a trusted proxy in that authentication model.
+        schema:
+          type: string
+      - name: exclude_recently_demoted_brokers
+        in: query
+        description: Whether to allow leader replicas to be moved to recently demoted brokers.
+        schema:
+          type: boolean
+          default: false
+      - name: exclude_recently_removed_brokers
+        in: query
+        description: Whether to allow replicas to be moved to recently removed broker.
+        schema:
+          type: boolean
+          default: true
+      - name: excluded_topics
+        in: query
+        description: Specify topic whose partition is excluded from replica movement.
+        schema:
+          type: string # topics regex
+          default: null
+          example: "__CruiseControl.%2A"
+      - name: get_response_schema
+        in: query
+        description: Whether to return JSON schema in response header or not.
+        schema:
+          type: boolean
+          default: false
+      - name: json
+        in: query
+        description: Whether to return in JSON format or not.
+        schema:
+          type: boolean
+          default: false
+      - name: skip_hard_goal_check
+        in: query
+        description: Whether to allow hard goals be skipped in proposal generation.
+        schema:
+          type: boolean
+          default: false
+      - name: use_ready_default_goals
+        in: query
+        description: Whether to only use ready goals to generate proposal.
+        schema:
+          type: boolean
+          default: false
+      - name: verbose
+        in: query
+        description: Return detailed state information.
+        schema:
+          type: boolean
+          default: false
+    responses:
+      '200':
+        description: Successful removed disks response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/optimizationResult.yaml#/OptimizationResult'
+          text/plain:
+            schema:
+              type: string
+      '202':
+        description: Remove disks in progress.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/progressResult.yaml#/ProgressResult'
+          text/plain:
+            schema:
+              type: string
+      # Response for all errors
+      default:
+        description: Error response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/errorResponse.yaml#/ErrorResponse'
+          text/plain:
+            schema:
+              type: string

--- a/cruise-control/src/yaml/endpoints/removeDisks.yaml
+++ b/cruise-control/src/yaml/endpoints/removeDisks.yaml
@@ -31,6 +31,7 @@ RemoveDisksEndpoint:
             items:
               type: string
         required: true
+        example: 101-/tmp/kafka-logs-1
       - name: skip_hard_goal_check
         in: query
         description: Whether to allow hard goals be skipped in proposal generation.

--- a/cruise-control/src/yaml/endpoints/removeDisks.yaml
+++ b/cruise-control/src/yaml/endpoints/removeDisks.yaml
@@ -9,32 +9,12 @@ RemoveDisksEndpoint:
         schema:
           type: boolean
           default: true
-      - name: goals
-        in: query
-        description: List of goals used to generate proposal, the default goals will be used if this parameter is not specified.
-        schema:
-          type: array
-          items:
-            type: string
-          example: ["RackAwareGoal", "ReplicaCapacityGoal", "ReplicaDistributionGoal"]
-      - name: allow_capacity_estimation
-        in: query
-        description: Whether to allow capacity estimation when cruise-control is unable to obtain all per-broker capacity information.
-        schema:
-          type: boolean
-          default: false
       - name: stop_ongoing_execution
         in: query
         description: Whether to stop the ongoing execution (if any) and start executing the given request.
         schema:
           type: boolean
           default: false
-      - name: fast_mode
-        in: query
-        description: True to compute proposals in fast mode, false otherwise
-        schema:
-          type: boolean
-          default: true
       - name: reason
         in: query
         description: Reason for request.
@@ -50,63 +30,10 @@ RemoveDisksEndpoint:
             type: array
             items:
               type: string
-      - name: data_from
-        in: query
-        description: Whether to calculate proposal from available valid partitions or valid windows.
-        schema:
-          type: string
-          default: VALID_WINDOWS
-      - name: doAs
-        in: query
-        description: The user specified by a trusted proxy in that authentication model.
-        schema:
-          type: string
-      - name: exclude_recently_demoted_brokers
-        in: query
-        description: Whether to allow leader replicas to be moved to recently demoted brokers.
-        schema:
-          type: boolean
-          default: false
-      - name: exclude_recently_removed_brokers
-        in: query
-        description: Whether to allow replicas to be moved to recently removed broker.
-        schema:
-          type: boolean
-          default: true
-      - name: excluded_topics
-        in: query
-        description: Specify topic whose partition is excluded from replica movement.
-        schema:
-          type: string # topics regex
-          default: null
-          example: "__CruiseControl.%2A"
-      - name: get_response_schema
-        in: query
-        description: Whether to return JSON schema in response header or not.
-        schema:
-          type: boolean
-          default: false
-      - name: json
-        in: query
-        description: Whether to return in JSON format or not.
-        schema:
-          type: boolean
-          default: false
+        required: true
       - name: skip_hard_goal_check
         in: query
         description: Whether to allow hard goals be skipped in proposal generation.
-        schema:
-          type: boolean
-          default: false
-      - name: use_ready_default_goals
-        in: query
-        description: Whether to only use ready goals to generate proposal.
-        schema:
-          type: boolean
-          default: false
-      - name: verbose
-        in: query
-        description: Return detailed state information.
         schema:
           type: boolean
           default: false

--- a/cruise-control/src/yaml/endpoints/removeDisks.yaml
+++ b/cruise-control/src/yaml/endpoints/removeDisks.yaml
@@ -31,7 +31,7 @@ RemoveDisksEndpoint:
             items:
               type: string
         required: true
-        example: 101-/tmp/kafka-logs-1
+        example: 101-/tmp/kafka-logs-1,101-/tmp/kafka-logs-2
       - name: skip_hard_goal_check
         in: query
         description: Whether to allow hard goals be skipped in proposal generation.


### PR DESCRIPTION
This PR introduces a new endpoint that moves replicas from a specified disk to another disk of the same broker. This will allow the removal of the disk without the loss of data.

### What is new

The new endpoint is available as follows:
`POST /remove_disks?brokerid_and_logdirs=[brokerid1-logdir1,brokerid2-logdir2...]`

### What is missing

After all replicas are moved from the specified disk, the disk may still be used by CC during rebalances and Kafka can still use it when creating topics.