### PR TITLE
[INTERNAL] - Revert log4j deps update from 1a199b5f7734d9ec5b8268cebcc24523d1104d06

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,8 +169,8 @@ project(':cruise-control-core') {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'log4j', module: 'log4j'
     }
-    implementation "org.slf4j:slf4j-api:2.0.3"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0"
+    implementation "org.slf4j:slf4j-api:1.7.36"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.17.2"
     implementation 'org.apache.commons:commons-math3:3.6.1'
     api "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
@@ -267,8 +267,8 @@ project(':cruise-control') {
 
     api project(':cruise-control-metrics-reporter')
     api project(':cruise-control-core')
-    implementation "org.slf4j:slf4j-api:2.0.3"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0"
+    implementation "org.slf4j:slf4j-api:1.7.36"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.17.2"
     implementation "org.apache.zookeeper:zookeeper:${zookeeperVersion}"
     implementation "io.netty:netty-handler:${nettyVersion}"
     implementation "io.netty:netty-transport-native-epoll:${nettyVersion}"
@@ -413,9 +413,9 @@ project(':cruise-control-metrics-reporter') {
       exclude group: 'log4j', module: 'log4j'
     }
 
-    implementation "org.slf4j:slf4j-api:2.0.3"
+    implementation "org.slf4j:slf4j-api:1.7.36
     implementation "com.yammer.metrics:metrics-core:2.2.0"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.19.0"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.17.2"
     implementation "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion"
     implementation "org.apache.kafka:kafka-clients:$kafkaVersion"
     implementation 'com.google.code.findbugs:jsr305:3.0.2'


### PR DESCRIPTION
This PR resolves log4j deps issue.
```
$ kubectl logs -f pipeline-kafka-cruisecontrol-74797cd6c4-zvmcs
W1206 16:34:08.297898   53910 azure.go:92] WARNING: the azure auth plugin is deprecated in v1.22+, unavailable in v1.26+; use https://github.com/Azure/kubelogin instead.
To learn more, consult https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
Defaulted container "pipeline-kafka-cruisecontrol" out of: pipeline-kafka-cruisecontrol, jmx-exporter (init)
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/opt/cruise-control/cruise-control/build/dependant-libs/log4j-slf4j-impl-2.19.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
>> ********************************************* <<
>> Application directory            : /opt/cruise-control
>> REST API available on            : /kafkacruisecontrol/*
>> Web UI available on              : /*
>> Web UI Directory                 : ./cruise-control-ui/dist/
>> Cookie prefix path               : /
>> Kafka Cruise Control started on  : http://0.0.0.0:8090/
>> CORS Enabled ?                   : false
>> ********************************************* <<
```
