### PR TITLE
Optimize empty partitions movements

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/ExecutorConfig.java
@@ -149,6 +149,19 @@ public final class ExecutorConfig {
       + "given point. This is to avoid overwhelming the cluster by inter-broker partition movements.";
 
   /**
+   * <code>num.concurrent.empty.partition.movements.per.broker</code>
+   */
+  public static final String NUM_CONCURRENT_EMPTY_PARTITION_MOVEMENTS_PER_BROKER_CONFIG =
+      "num.concurrent.empty.partition.movements.per.broker";
+  public static final int DEFAULT_NUM_CONCURRENT_EMPTY_PARTITION_MOVEMENTS_PER_BROKER = 100;
+  public static final String NUM_CONCURRENT_EMPTY_PARTITION_MOVEMENTS_PER_BROKER_DOC = "The maximum number of empty "
+      + "(zero-byte) partitions the executor will move to or out of a broker at the same time. Since empty partition "
+      + "moves transfer no data and create no I/O pressure, a much higher concurrency than "
+      + NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_CONFIG + " is safe. This limit is applied on top of (not instead "
+      + "of) the normal partition movement concurrency -- zero-byte moves that fit within the normal limit use normal "
+      + "slots first, and only overflow into this extended limit.";
+
+  /**
    * <code>num.concurrent.intra.broker.partition.movements</code>
    */
   public static final String NUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_CONFIG = "num.concurrent.intra.broker.partition.movements";
@@ -706,6 +719,12 @@ public final class ExecutorConfig {
                             atLeast(1),
                             ConfigDef.Importance.MEDIUM,
                             NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_DOC)
+                    .define(NUM_CONCURRENT_EMPTY_PARTITION_MOVEMENTS_PER_BROKER_CONFIG,
+                            ConfigDef.Type.INT,
+                            DEFAULT_NUM_CONCURRENT_EMPTY_PARTITION_MOVEMENTS_PER_BROKER,
+                            atLeast(1),
+                            ConfigDef.Importance.MEDIUM,
+                            NUM_CONCURRENT_EMPTY_PARTITION_MOVEMENTS_PER_BROKER_DOC)
                     .define(NUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_CONFIG,
                             ConfigDef.Type.INT,
                             DEFAULT_NUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskManager.java
@@ -79,7 +79,8 @@ public class ExecutionTaskManager {
                                                                                           ConcurrencyType.INTER_BROKER_REPLICA);
     return _executionTaskPlanner.getInterBrokerReplicaMovementTasks(
         brokersReadyForReplicaMovement, _inProgressPartitionsForInterBrokerMovement,
-        _executionConcurrencyManager.maxClusterInterBrokerPartitionMovements());
+        _executionConcurrencyManager.maxClusterInterBrokerPartitionMovements(),
+        _executionConcurrencyManager.emptyPartitionMovementConcurrency());
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -343,6 +343,8 @@ public class ExecutionTaskPlanner {
    *                             controller does not allow updating the ongoing replica reassignment for a partition
    *                             whose replica is being reassigned.
    * @param maxInterBrokerPartitionMovements Maximum cap for number of partitions to move at any time
+   * @param maxEmptyPartitionMovementsPerBroker Maximum concurrent empty (zero-byte) partition moves per broker,
+   *                                            used as an extended limit beyond the normal readyBrokers slots.
    * @return A list of movements that is executable for the ready brokers.
    */
   public List<ExecutionTask> getInterBrokerReplicaMovementTasks(Map<Integer, Integer> readyBrokers,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -347,11 +347,19 @@ public class ExecutionTaskPlanner {
    */
   public List<ExecutionTask> getInterBrokerReplicaMovementTasks(Map<Integer, Integer> readyBrokers,
                                                                 Set<TopicPartition> inProgressPartitions,
-                                                                int maxInterBrokerPartitionMovements) {
+                                                                int maxInterBrokerPartitionMovements,
+                                                                int maxEmptyPartitionMovementsPerBroker) {
     LOG.trace("Getting inter-broker replica movement tasks for brokers with concurrency {}", readyBrokers);
     List<ExecutionTask> executableReplicaMovements = new ArrayList<>();
     SortedSet<Integer> interPartMoveBrokerIds = new TreeSet<>(_interPartMoveBrokerComparator);
     List<Integer> interPartMoveBrokerIdsList = new ArrayList<>(_interPartMoveTasksByBrokerId.keySet().size());
+
+    // Separate slot tracking for zero-byte (empty) partition moves. These slots are used only after
+    // normal readyBrokers slots are exhausted, allowing empty partition moves to proceed at higher concurrency.
+    Map<Integer, Integer> readyBrokersEmptyPartitions = new HashMap<>();
+    for (Map.Entry<Integer, Integer> entry : readyBrokers.entrySet()) {
+      readyBrokersEmptyPartitions.put(entry.getKey(), maxEmptyPartitionMovementsPerBroker);
+    }
 
     /*
      * The algorithm avoids unfair situation where the available movement slots of a broker is completely taken
@@ -403,33 +411,39 @@ public class ExecutionTaskPlanner {
             continue;
           }
           TopicPartition tp = task.proposal().topicPartition();
-          // Check if the proposal is executable.
-          if (isExecutableProposal(task.proposal(), readyBrokers)
-              && !inProgressPartitions.contains(tp)
-              && !partitionsInvolved.contains(tp)) {
+          if (inProgressPartitions.contains(tp) || partitionsInvolved.contains(tp)) {
+            continue;
+          }
+
+          boolean isZeroByte = task.proposal().dataToMoveInMB() == 0;
+          // Try normal slots first; for zero-byte tasks that don't fit normal slots, try the extended limit.
+          boolean executable = isExecutableProposal(task.proposal(), readyBrokers);
+          boolean useEmptySlots = false;
+          if (!executable && isZeroByte) {
+            executable = isExecutableProposal(task.proposal(), readyBrokersEmptyPartitions);
+            useEmptySlots = executable;
+          }
+
+          if (executable) {
             partitionsInvolved.add(tp);
             executableReplicaMovements.add(task);
-            // Record the brokers as involved in this round and stop involving them again in this round.
             brokerInvolved.add(sourceBroker);
             brokerInvolved.addAll(destinationBrokers);
-            // The first task of each involved broker might have changed.
-            // Let's remove the brokers before the tasks change, then add them again later by comparing their new first tasks.
             interPartMoveBrokerIds.remove(sourceBroker);
             interPartMoveBrokerIds.removeAll(destinationBrokers);
-            // Remove the proposal from the execution plan.
             removeInterBrokerReplicaActionForExecution(task);
             interPartMoveBrokerIds.add(sourceBroker);
             interPartMoveBrokerIds.addAll(destinationBrokers);
-            // Decrement the slots for both source and destination brokers
-            readyBrokers.put(sourceBroker, readyBrokers.get(sourceBroker) - 1);
+
+            Map<Integer, Integer> slotsToDecrement = useEmptySlots ? readyBrokersEmptyPartitions : readyBrokers;
+            slotsToDecrement.put(sourceBroker, slotsToDecrement.get(sourceBroker) - 1);
             for (int broker : destinationBrokers) {
-              readyBrokers.put(broker, readyBrokers.get(broker) - 1);
+              slotsToDecrement.put(broker, slotsToDecrement.get(broker) - 1);
             }
-            // Mark proposal added to true so we will have another round of check.
             newTaskAdded = true;
             numInProgressPartitions++;
-            LOG.debug("Found ready task {} for broker {}. Broker concurrency state: {}", task, brokerId, readyBrokers);
-            // We can stop the check for proposals for this broker because we have found a proposal.
+            LOG.debug("Found ready task {} for broker {}. Broker concurrency state: {}, empty partition state: {}",
+                      task, brokerId, readyBrokers, readyBrokersEmptyPartitions);
             break;
           }
         }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -85,6 +85,7 @@ public class Executor {
   private static final Logger LOG = LoggerFactory.getLogger(Executor.class);
   private static final Logger OPERATION_LOG = LoggerFactory.getLogger(OPERATION_LOGGER);
   private static final long EXECUTION_PROGRESS_CHECK_INTERVAL_ADJUSTING_MS = 1000;
+  static final long ZERO_BYTE_MOVE_INITIAL_CHECK_DELAY_MS = 1000;
   // The execution progress is controlled by the ExecutionTaskManager.
   private final ExecutionTaskManager _executionTaskManager;
   private final MetadataClient _metadataClient;
@@ -1837,7 +1838,9 @@ public class Executor {
             totalDataInMB += task.proposal().dataToMoveInMB();
           }
           if (totalDataInMB == 0 && !inExecutionTasks().isEmpty()) {
-            LOG.debug("All in-execution tasks are zero-byte moves, skipping initial sleep.");
+            LOG.debug("All in-execution tasks are zero-byte moves, using reduced initial delay of {}ms.",
+                      ZERO_BYTE_MOVE_INITIAL_CHECK_DELAY_MS);
+            Thread.sleep(ZERO_BYTE_MOVE_INITIAL_CHECK_DELAY_MS);
             cluster = _metadataClient.refreshMetadata().cluster();
           } else {
             cluster = getClusterForExecutionProgressCheck();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/Executor.java
@@ -1827,8 +1827,24 @@ public class Executor {
       }
 
       boolean retry;
+      boolean isFirstIteration = true;
       do {
-        Cluster cluster = getClusterForExecutionProgressCheck();
+        Cluster cluster;
+        if (isFirstIteration) {
+          isFirstIteration = false;
+          long totalDataInMB = 0;
+          for (ExecutionTask task : inExecutionTasks()) {
+            totalDataInMB += task.proposal().dataToMoveInMB();
+          }
+          if (totalDataInMB == 0 && !inExecutionTasks().isEmpty()) {
+            LOG.debug("All in-execution tasks are zero-byte moves, skipping initial sleep.");
+            cluster = _metadataClient.refreshMetadata().cluster();
+          } else {
+            cluster = getClusterForExecutionProgressCheck();
+          }
+        } else {
+          cluster = getClusterForExecutionProgressCheck();
+        }
         List<ExecutionTask> deadInterBrokerReplicaTasks = new ArrayList<>();
         List<ExecutionTask> stoppedInterBrokerReplicaTasks = new ArrayList<>();
         List<ExecutionTask> slowTasksToReport = new ArrayList<>();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/InterBrokerConcurrencyLimits.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/InterBrokerConcurrencyLimits.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.executor;
+
+/**
+ * Immutable holder for the two concurrency limits passed to
+ * {@link ExecutionTaskPlanner#getInterBrokerReplicaMovementTasks}: the cluster-wide cap on normal inter-broker
+ * partition movements and the per-broker extended cap for empty (sub-1 MB) partition movements.
+ *
+ * <p>Using a named type instead of two adjacent {@code int} parameters eliminates the silent swap hazard at call
+ * sites, where the two values have similar types and magnitudes.</p>
+ */
+public final class InterBrokerConcurrencyLimits {
+  /** Maximum number of inter-broker partition movements in flight cluster-wide at any time. */
+  public final int maxPartitionMovements;
+
+  /** Per-broker concurrency cap for empty (sub-1 MB) partition moves, applied as an extended limit on top of normal slots. */
+  public final int maxEmptyPartitionMovementsPerBroker;
+
+  public InterBrokerConcurrencyLimits(int maxPartitionMovements, int maxEmptyPartitionMovementsPerBroker) {
+    this.maxPartitionMovements = maxPartitionMovements;
+    this.maxEmptyPartitionMovementsPerBroker = maxEmptyPartitionMovementsPerBroker;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/concurrency/ExecutionConcurrencyManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/concurrency/ExecutionConcurrencyManager.java
@@ -37,6 +37,9 @@ public class ExecutionConcurrencyManager {
   // The total allowed movement concurrency for all types in the cluster. This value cannot be overridden at runtime.
   private final int _clusterMovementConcurrency;
 
+  // The allowed per-broker concurrency for empty (zero-byte) partition movements.
+  private final int _defaultEmptyPartitionMovementConcurrency;
+
   // The allowed inter-broker partition movement concurrency for each broker.
   private final int _defaultInterBrokerPartitionMovementConcurrency;
   private Integer _requestedInterBrokerPartitionMovementConcurrency;
@@ -74,6 +77,8 @@ public class ExecutionConcurrencyManager {
 
   public ExecutionConcurrencyManager(KafkaCruiseControlConfig config) {
     _clusterMovementConcurrency = config.getInt(ExecutorConfig.MAX_NUM_CLUSTER_MOVEMENTS_CONFIG);
+    _defaultEmptyPartitionMovementConcurrency = config.getInt(
+        ExecutorConfig.NUM_CONCURRENT_EMPTY_PARTITION_MOVEMENTS_PER_BROKER_CONFIG);
     _defaultInterBrokerPartitionMovementConcurrency = config.getInt(ExecutorConfig.NUM_CONCURRENT_PARTITION_MOVEMENTS_PER_BROKER_CONFIG);
     _defaultIntraBrokerPartitionMovementConcurrency = config.getInt(ExecutorConfig.NUM_CONCURRENT_INTRA_BROKER_PARTITION_MOVEMENTS_CONFIG);
     _defaultClusterLeadershipMovementConcurrency = config.getInt(ExecutorConfig.NUM_CONCURRENT_LEADER_MOVEMENTS_CONFIG);
@@ -282,6 +287,13 @@ public class ExecutionConcurrencyManager {
   public synchronized int maxClusterLeadershipMovements() {
     return _requestedClusterLeadershipMovementConcurrency == null ? _defaultClusterLeadershipMovementConcurrency
                                                                             : _requestedClusterLeadershipMovementConcurrency;
+  }
+
+  /**
+   * @return The per-broker concurrency allowed for empty (zero-byte) partition movements.
+   */
+  public int emptyPartitionMovementConcurrency() {
+    return _defaultEmptyPartitionMovementConcurrency;
   }
 
   /**

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
@@ -525,14 +525,15 @@ public class ExecutionTaskPlannerTest {
 
   @Test
   public void testMixedZeroByteAndDataBearingTasks() {
-    // 3 zero-byte proposals + 3 data-bearing proposals, all from broker 0 to broker 1.
+    // Data-bearing proposals added first so they consume the normal slot,
+    // then zero-byte proposals which should overflow into empty-partition slots.
     List<ExecutionProposal> proposals = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
-      proposals.add(new ExecutionProposal(new TopicPartition(TOPIC1, i), 0, _r0,
+      proposals.add(new ExecutionProposal(new TopicPartition(TOPIC1, i), 100, _r0,
                                           Arrays.asList(_r0, _r2), Arrays.asList(_r2, _r1)));
     }
     for (int i = 3; i < 6; i++) {
-      proposals.add(new ExecutionProposal(new TopicPartition(TOPIC1, i), 100, _r0,
+      proposals.add(new ExecutionProposal(new TopicPartition(TOPIC1, i), 0, _r0,
                                           Arrays.asList(_r0, _r2), Arrays.asList(_r2, _r1)));
     }
 
@@ -557,22 +558,20 @@ public class ExecutionTaskPlannerTest {
     List<ExecutionTask> tasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
                                                                            _defaultPartitionsMaxCap, 50);
 
-    // 1 task (data-bearing or zero-byte) uses the normal slot, then remaining zero-byte tasks use empty slots.
-    // Due to round-robin, up to 4 tasks total can be scheduled (1 normal + 3 zero-byte via empty slots, or similar).
-    // At minimum, more than just the normal concurrency (1) should be scheduled.
     int dataBearingCount = 0;
-    int zeroBytCount = 0;
+    int zeroByteCount = 0;
     for (ExecutionTask t : tasks) {
       if (t.proposal().dataToMoveInMB() == 0) {
-        zeroBytCount++;
+        zeroByteCount++;
       } else {
         dataBearingCount++;
       }
     }
-    // Normal slots allow 1 task per broker (min of src/dst). That uses 1 normal slot.
-    // After that, zero-byte tasks can still use the empty-partition slots.
+    // The first data-bearing proposal consumes the single normal slot per broker.
+    // After that, remaining data-bearing tasks can't be scheduled (no normal slots, not zero-byte).
+    // All 3 zero-byte tasks are then scheduled via the empty-partition slots.
     assertEquals("Only 1 data-bearing task should be scheduled with normal concurrency 1", 1, dataBearingCount);
-    assertEquals("All 3 zero-byte tasks should be scheduled via empty partition slots", 3, zeroBytCount);
+    assertEquals("All 3 zero-byte tasks should be scheduled via empty partition slots", 3, zeroByteCount);
   }
 
   @Test

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlannerTest.java
@@ -98,6 +98,7 @@ public class ExecutionTaskPlannerTest {
                                                        new Node(4, "null", -1),
                                                        new Node(5, "null", -1));
   private final int _defaultPartitionsMaxCap = ExecutorConfig.DEFAULT_MAX_NUM_CLUSTER_PARTITION_MOVEMENTS_CONFIG;
+  private final int _defaultEmptyPartitionConcurrency = ExecutorConfig.DEFAULT_NUM_CONCURRENT_EMPTY_PARTITION_MOVEMENTS_PER_BROKER;
 
   @Test
   public void testGetLeaderMovementTasks() {
@@ -265,28 +266,32 @@ public class ExecutionTaskPlannerTest {
 
     basePlanner.addExecutionProposals(proposals, strategyOptions, null);
     List<ExecutionTask> partitionMovementTasks = basePlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
-                                                                                                _defaultPartitionsMaxCap);
+                                                                                                _defaultPartitionsMaxCap,
+                                                                                                _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement0, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement1, partitionMovementTasks.get(2).proposal());
 
     postponeUrpPlanner.addExecutionProposals(proposals, strategyOptions, null);
     partitionMovementTasks = postponeUrpPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
-                                                                                   _defaultPartitionsMaxCap);
+                                                                                   _defaultPartitionsMaxCap,
+                                                                                   _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement1, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement0, partitionMovementTasks.get(2).proposal());
 
     prioritizeLargeMovementPlanner.addExecutionProposals(proposals, strategyOptions, null);
     partitionMovementTasks = prioritizeLargeMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
-                                                                                               _defaultPartitionsMaxCap);
+                                                                                               _defaultPartitionsMaxCap,
+                                                                                               _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement1, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement2, partitionMovementTasks.get(2).proposal());
 
     prioritizeSmallMovementPlanner.addExecutionProposals(proposals, strategyOptions, null);
     partitionMovementTasks = prioritizeSmallMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
-                                                                                               _defaultPartitionsMaxCap);
+                                                                                               _defaultPartitionsMaxCap,
+                                                                                               _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement0, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement3, partitionMovementTasks.get(2).proposal());
@@ -294,7 +299,8 @@ public class ExecutionTaskPlannerTest {
 
     smallUrpMovementPlanner.addExecutionProposals(proposals, strategyOptions, null);
     partitionMovementTasks = smallUrpMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
-                                                                                        _defaultPartitionsMaxCap);
+                                                                                        _defaultPartitionsMaxCap,
+                                                                                        _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement3, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement1, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement0, partitionMovementTasks.get(2).proposal());
@@ -302,7 +308,8 @@ public class ExecutionTaskPlannerTest {
 
     contradictingMovementPlanner.addExecutionProposals(proposals, strategyOptions, null);
     partitionMovementTasks = contradictingMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
-                                                                                             _defaultPartitionsMaxCap);
+                                                                                             _defaultPartitionsMaxCap,
+                                                                                             _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement3, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement1, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement0, partitionMovementTasks.get(2).proposal());
@@ -310,7 +317,8 @@ public class ExecutionTaskPlannerTest {
 
     prioritizeMinIsrMovementPlanner.addExecutionProposals(proposals, strategyOptions, null);
     partitionMovementTasks = prioritizeMinIsrMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
-                                                                                                _defaultPartitionsMaxCap);
+                                                                                                _defaultPartitionsMaxCap,
+                                                                                                _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement0, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement1, partitionMovementTasks.get(2).proposal());
@@ -354,7 +362,8 @@ public class ExecutionTaskPlannerTest {
     readyBrokers.put(5, 6);
     prioritizeOneAboveMinIsrMovementPlanner.addExecutionProposals(proposals, strategyOptions, null);
     List<ExecutionTask> partitionMovementTasks
-        = prioritizeOneAboveMinIsrMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(), _defaultPartitionsMaxCap);
+        = prioritizeOneAboveMinIsrMovementPlanner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
+                                                                                     _defaultPartitionsMaxCap, _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _rf4PartitionMovement2, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _rf4PartitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _rf4PartitionMovement1, partitionMovementTasks.get(2).proposal());
@@ -387,25 +396,32 @@ public class ExecutionTaskPlannerTest {
     readyBrokers.put(3, 8);
     planner.addExecutionProposals(proposals, strategyOptions, null);
     List<ExecutionTask> partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
-                                                                                            _defaultPartitionsMaxCap);
+                                                                                            _defaultPartitionsMaxCap,
+                                                                                            _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement0, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement1, partitionMovementTasks.get(2).proposal());
 
     planner.addExecutionProposals(proposals, strategyOptions, new PostponeUrpReplicaMovementStrategy());
-    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(), _defaultPartitionsMaxCap);
+    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
+                                                                        _defaultPartitionsMaxCap,
+                                                                        _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement1, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement0, partitionMovementTasks.get(2).proposal());
 
     planner.addExecutionProposals(proposals, strategyOptions, new PrioritizeLargeReplicaMovementStrategy());
-    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(), _defaultPartitionsMaxCap);
+    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
+                                                                        _defaultPartitionsMaxCap,
+                                                                        _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement1, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement3, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement2, partitionMovementTasks.get(2).proposal());
 
     planner.addExecutionProposals(proposals, strategyOptions, new PrioritizeSmallReplicaMovementStrategy());
-    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(), _defaultPartitionsMaxCap);
+    partitionMovementTasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
+                                                                        _defaultPartitionsMaxCap,
+                                                                        _defaultEmptyPartitionConcurrency);
     assertEquals("First task", _partitionMovement0, partitionMovementTasks.get(0).proposal());
     assertEquals("Second task", _partitionMovement2, partitionMovementTasks.get(1).proposal());
     assertEquals("Third task", _partitionMovement3, partitionMovementTasks.get(2).proposal());
@@ -472,6 +488,124 @@ public class ExecutionTaskPlannerTest {
     assertEquals(0, planner.remainingLeadershipMovements().size());
     assertEquals(0, planner.remainingIntraBrokerReplicaMovements().size());
     EasyMock.verify(mockAdminClient);
+  }
+
+  @Test
+  public void testZeroByteTasksExceedNormalConcurrency() {
+    // Create 10 zero-byte proposals all moving from broker 0 to broker 1.
+    List<ExecutionProposal> proposals = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      proposals.add(new ExecutionProposal(new TopicPartition(TOPIC1, i), 0, _r0,
+                                          Arrays.asList(_r0, _r2), Arrays.asList(_r2, _r1)));
+    }
+
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, new KafkaCruiseControlConfig(props));
+
+    Set<PartitionInfo> partitions = new HashSet<>();
+    for (ExecutionProposal p : proposals) {
+      partitions.add(generatePartitionInfo(p, false));
+    }
+    Cluster cluster = new Cluster(null, _expectedNodes, partitions, Collections.emptySet(), Collections.emptySet());
+    StrategyOptions strategyOptions = new StrategyOptions.Builder(cluster).build();
+
+    planner.addExecutionProposals(proposals, strategyOptions, null);
+
+    // Normal concurrency is 2 per broker -- too low for 10 proposals.
+    Map<Integer, Integer> readyBrokers = new HashMap<>();
+    readyBrokers.put(0, 2);
+    readyBrokers.put(1, 2);
+    readyBrokers.put(2, 2);
+
+    // With empty-partition concurrency of 50, all 10 zero-byte tasks should be scheduled.
+    List<ExecutionTask> tasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
+                                                                           _defaultPartitionsMaxCap, 50);
+    assertEquals("All 10 zero-byte tasks should be scheduled", 10, tasks.size());
+  }
+
+  @Test
+  public void testMixedZeroByteAndDataBearingTasks() {
+    // 3 zero-byte proposals + 3 data-bearing proposals, all from broker 0 to broker 1.
+    List<ExecutionProposal> proposals = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      proposals.add(new ExecutionProposal(new TopicPartition(TOPIC1, i), 0, _r0,
+                                          Arrays.asList(_r0, _r2), Arrays.asList(_r2, _r1)));
+    }
+    for (int i = 3; i < 6; i++) {
+      proposals.add(new ExecutionProposal(new TopicPartition(TOPIC1, i), 100, _r0,
+                                          Arrays.asList(_r0, _r2), Arrays.asList(_r2, _r1)));
+    }
+
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, new KafkaCruiseControlConfig(props));
+
+    Set<PartitionInfo> partitions = new HashSet<>();
+    for (ExecutionProposal p : proposals) {
+      partitions.add(generatePartitionInfo(p, false));
+    }
+    Cluster cluster = new Cluster(null, _expectedNodes, partitions, Collections.emptySet(), Collections.emptySet());
+    StrategyOptions strategyOptions = new StrategyOptions.Builder(cluster).build();
+
+    planner.addExecutionProposals(proposals, strategyOptions, null);
+
+    // Normal concurrency of 1 per broker.
+    Map<Integer, Integer> readyBrokers = new HashMap<>();
+    readyBrokers.put(0, 1);
+    readyBrokers.put(1, 1);
+    readyBrokers.put(2, 1);
+
+    List<ExecutionTask> tasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
+                                                                           _defaultPartitionsMaxCap, 50);
+
+    // 1 task (data-bearing or zero-byte) uses the normal slot, then remaining zero-byte tasks use empty slots.
+    // Due to round-robin, up to 4 tasks total can be scheduled (1 normal + 3 zero-byte via empty slots, or similar).
+    // At minimum, more than just the normal concurrency (1) should be scheduled.
+    int dataBearingCount = 0;
+    int zeroBytCount = 0;
+    for (ExecutionTask t : tasks) {
+      if (t.proposal().dataToMoveInMB() == 0) {
+        zeroBytCount++;
+      } else {
+        dataBearingCount++;
+      }
+    }
+    // Normal slots allow 1 task per broker (min of src/dst). That uses 1 normal slot.
+    // After that, zero-byte tasks can still use the empty-partition slots.
+    assertEquals("Only 1 data-bearing task should be scheduled with normal concurrency 1", 1, dataBearingCount);
+    assertEquals("All 3 zero-byte tasks should be scheduled via empty partition slots", 3, zeroBytCount);
+  }
+
+  @Test
+  public void testClusterWideCapRespectedForZeroByteTasks() {
+    // Create 20 zero-byte proposals.
+    List<ExecutionProposal> proposals = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      proposals.add(new ExecutionProposal(new TopicPartition(TOPIC1, i), 0, _r0,
+                                          Arrays.asList(_r0, _r2), Arrays.asList(_r2, _r1)));
+    }
+
+    Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();
+    ExecutionTaskPlanner planner = new ExecutionTaskPlanner(null, new KafkaCruiseControlConfig(props));
+
+    Set<PartitionInfo> partitions = new HashSet<>();
+    for (ExecutionProposal p : proposals) {
+      partitions.add(generatePartitionInfo(p, false));
+    }
+    Cluster cluster = new Cluster(null, _expectedNodes, partitions, Collections.emptySet(), Collections.emptySet());
+    StrategyOptions strategyOptions = new StrategyOptions.Builder(cluster).build();
+
+    planner.addExecutionProposals(proposals, strategyOptions, null);
+
+    Map<Integer, Integer> readyBrokers = new HashMap<>();
+    readyBrokers.put(0, 2);
+    readyBrokers.put(1, 2);
+    readyBrokers.put(2, 2);
+
+    // Set cluster-wide cap to 5 -- should stop at 5 even though empty concurrency allows more.
+    int clusterWideCap = 5;
+    List<ExecutionTask> tasks = planner.getInterBrokerReplicaMovementTasks(readyBrokers, Collections.emptySet(),
+                                                                           clusterWideCap, 100);
+    assertEquals("Cluster-wide cap should be respected", clusterWideCap, tasks.size());
   }
 
   @Test

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/executor/ExecutorTest.java
@@ -839,6 +839,32 @@ public class ExecutorTest extends CCKafkaClientsIntegrationTestHarness {
     assertFalse("Concurrency manager is not reset after execution", executor.isConcurrencyManagerInitialized());
   }
 
+  @Test
+  public void testZeroByteMoveExecution() throws InterruptedException, OngoingExecutionException {
+    KafkaZkClient kafkaZkClient = KafkaCruiseControlUtils.createKafkaZkClient(zookeeper().connectionString(),
+                                                                              "ExecutorTestMetricGroup",
+                                                                              "ZeroByteMoveExecution",
+                                                                              false,
+                                                                              _zkClientConfig);
+    try {
+      Map<String, TopicDescription> topicDescriptions = createTopics(0);
+      int initialLeader0 = topicDescriptions.get(TOPIC0).partitions().get(0).leader().id();
+      int targetBroker = initialLeader0 == 0 ? 1 : 0;
+
+      // Zero-byte inter-broker move: exercises the reduced-delay first-iteration path
+      // in waitForInterBrokerReplicaTasksToFinish.
+      ExecutionProposal proposal =
+          new ExecutionProposal(TP0, 0, new ReplicaPlacementInfo(initialLeader0),
+                                Collections.singletonList(new ReplicaPlacementInfo(initialLeader0)),
+                                Collections.singletonList(new ReplicaPlacementInfo(targetBroker)));
+
+      executeAndVerifyProposals(kafkaZkClient, Collections.singletonList(proposal),
+                                Collections.singletonList(proposal), false, null, false, true);
+    } finally {
+      KafkaCruiseControlUtils.closeKafkaZkClientWithTimeout(kafkaZkClient);
+    }
+  }
+
   private Properties getExecutorProperties() {
     Properties props = new Properties();
     String capacityConfigFile = Objects.requireNonNull(


### PR DESCRIPTION
## Summary
1. Why: Moving empty partitions is slow
2. What: Batch more empty partitions within data movement assignments

## Expected Behavior
…

## Actual Behavior
…

## Steps to Reproduce
1. …
2. …

## Known Workarounds
<!-- if any -->

## Additional evidence
1. <!-- your environment -->
2. <!-- logs --> 
3. <!-- etc… -->
4. <!-- use <detail> tag for large snippets -->

## Categorization
- [ ] documentation
- [ ] bugfix
- [ ] new feature
- [ ] refactor
- [ ] security/CVE
- [ ] other

This PR resolves #<Replace-Me-With-The-Issue-Number-Addressed-By-This-PR> if any.
